### PR TITLE
Signup page added

### DIFF
--- a/v2/src/app/[locale]/signup/page.tsx
+++ b/v2/src/app/[locale]/signup/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import Signup from "@/components/Signup";
+
+export default function SignupPage() {
+  return <Signup />;
+}

--- a/v2/src/components/Login/index.tsx
+++ b/v2/src/components/Login/index.tsx
@@ -65,11 +65,14 @@ const Login = () => {
         <Box
           sx={{
             margin: "1rem",
-            justifyContent: "center",
-            alignItems: "center"
+            textAlign: "center", 
+            display: "flex", 
+            flexDirection: "column", 
+            gap: "1rem"
           }}
         >
-          <p className='titleTxt'>{t('login.header')}</p>
+          <p className='titleTxt'>{t('common.orgDashboardTitle')}</p>
+          <p className='titleTxt'>{t('login.title')}</p>
         </Box>
         <form onSubmit={handleSubmit}>
           <Box className='text-field'>
@@ -150,6 +153,13 @@ const Login = () => {
             }
             style={{ color: "#A1A1A1" }}
           />
+        </Box>
+        <Box sx={{ width: "100%", marginTop: ".5em", display: "flex", justifyContent: "center" }}>
+          <Typography variant="body2" style={{ color: "#A1A1A1" }}>
+            {t('login.noAccount')}
+            {' '}
+            <Link href="/signup">{t('login.signup')}</Link>
+          </Typography>
         </Box>
       </Box>
     </Box>

--- a/v2/src/components/Signup/index.tsx
+++ b/v2/src/components/Signup/index.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import React, { useState } from 'react';
+import { Box, Divider, TextField, IconButton, Typography } from "@mui/material";
+import { ArrowCircleRightIcon, UserIcon, LockOpenIcon } from "@phosphor-icons/react";
+import Logo from '@/assets/img/logo.jpg';
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+import Image from 'next/image';
+import './style.scss';
+import { useSignup } from '@/custom-hooks/auth';
+
+interface FormValue {
+  name: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+}
+
+const Signup = () => {
+  const t = useTranslations();
+  const [formValue, setFormValue] = useState<FormValue>({ name: '', email: '', password: '', confirmPassword: '' });
+  const { name, email, password, confirmPassword } = formValue;
+  const { signup: doSignup, isLoading } = useSignup();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // Basic validations
+    if (!email || !password) return;
+    if (password !== confirmPassword) return;
+
+    doSignup({ email, password, name: name || undefined });
+  };
+
+  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      handleSubmit(e);
+    }
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target as HTMLInputElement;
+    setFormValue({
+      ...formValue,
+      [name]: value
+    });
+  };
+
+  return (
+    <Box className="loginWrapper">
+      <Box className='loginContainer'>
+        <Box className='d-flex-center'>
+          <Link href="/">
+            <Image className="logoImg" src={Logo} alt="Logo" width={180} height={180} priority />
+          </Link>
+        </Box>
+        <Box sx={{ margin: "1rem", textAlign: "center", gap: "1rem", display: "flex", flexDirection: "column" }}>
+          <p className='titleTxt'>{t('common.orgDashboardTitle')}</p>
+          <p className='titleTxt'>{t('signup.title')}</p>
+        </Box>
+        <form onSubmit={handleSubmit}>
+          <Box className='text-field'>
+            <TextField
+              name="name"
+              type="text"
+              value={name}
+              onChange={handleChange}
+              variant="standard"
+              label={false}
+              placeholder={t('signup.name')}
+              fullWidth
+              slotProps={{
+                input: {
+                  startAdornment: (
+                    <UserIcon size={22} style={{ color: "#777", marginRight: "0.5rem", transform: "translateY(-2px)" }} />
+                  ),
+                  disableUnderline: true,
+                  onKeyPress: handleKeyPress,
+                }
+              }}
+            />
+            <Divider />
+            <TextField
+              name="email"
+              type="email"
+              value={email}
+              onChange={handleChange}
+              variant="standard"
+              label={false}
+              placeholder={t('signup.email')}
+              fullWidth
+              slotProps={{
+                input: {
+                  startAdornment: (
+                    <UserIcon size={22} style={{ color: "#777", marginRight: "0.5rem", transform: "translateY(-2px)" }} />
+                  ),
+                  disableUnderline: true,
+                  onKeyPress: handleKeyPress,
+                }
+              }}
+            />
+            <Divider />
+            <TextField
+              name="password"
+              type="password"
+              value={password}
+              onChange={handleChange}
+              variant="standard"
+              label={false}
+              placeholder={t('login.password')}
+              fullWidth
+              slotProps={{
+                input: {
+                  startAdornment: <LockOpenIcon size={22} style={{ color: "#777", marginRight: "0.5rem", transform: "translateY(-2px)" }} />,
+                  disableUnderline: true,
+                  onKeyPress: handleKeyPress,
+                }
+              }}
+            />
+            <Divider />
+            <TextField
+              name="confirmPassword"
+              type="password"
+              value={confirmPassword}
+              onChange={handleChange}
+              variant="standard"
+              label={false}
+              placeholder={t('signup.confirmPassword')}
+              fullWidth
+              slotProps={{
+                input: {
+                  startAdornment: <LockOpenIcon size={22} style={{ color: "#777", marginRight: "0.5rem", transform: "translateY(-2px)" }} />,
+                  disableUnderline: true,
+                  onKeyPress: handleKeyPress,
+                  endAdornment: (
+                    <IconButton type="submit" disabled={isLoading}>
+                      <ArrowCircleRightIcon
+                        size={22}
+                        style={{ color: "#888", cursor: "pointer", transform: "translateY(-2px)" }}
+                      />
+                    </IconButton>
+                  ),
+                }
+              }}
+            />
+          </Box>
+        </form>
+        <Box sx={{ width: "100%", marginTop: ".5em", display: "flex", justifyContent: "center" }}>
+          <Typography variant="body2" style={{ color: "#A1A1A1" }}>
+            {t('signup.haveAccount')}
+            {' '}
+            <Link href="/login">{t('signup.login')}</Link>
+          </Typography>
+        </Box>
+      </Box>
+    </Box>
+  )
+}
+
+export default Signup;

--- a/v2/src/components/Signup/index.tsx
+++ b/v2/src/components/Signup/index.tsx
@@ -9,6 +9,8 @@ import { useTranslations } from 'next-intl';
 import Image from 'next/image';
 import './style.scss';
 import { useSignup } from '@/custom-hooks/auth';
+import { useAppDispatch } from '@/custom-hooks/store';
+import { setMessage } from '@/store/reducers/authReducer';
 
 interface FormValue {
   name: string;
@@ -22,12 +24,17 @@ const Signup = () => {
   const [formValue, setFormValue] = useState<FormValue>({ name: '', email: '', password: '', confirmPassword: '' });
   const { name, email, password, confirmPassword } = formValue;
   const { signup: doSignup, isLoading } = useSignup();
+  const dispatch = useAppDispatch();
+  const passwordsMismatch = confirmPassword.length > 0 && password !== confirmPassword;
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     // Basic validations
     if (!email || !password) return;
-    if (password !== confirmPassword) return;
+    if (password !== confirmPassword) {
+      dispatch(setMessage(t('signup.passwordMismatch')));
+      return;
+    }
 
     doSignup({ email, password, name: name || undefined });
   };
@@ -87,7 +94,7 @@ const Signup = () => {
               onChange={handleChange}
               variant="standard"
               label={false}
-              placeholder={t('signup.email')}
+              placeholder={t('signup.userId')}
               fullWidth
               slotProps={{
                 input: {
@@ -127,17 +134,18 @@ const Signup = () => {
               label={false}
               placeholder={t('signup.confirmPassword')}
               fullWidth
+              error={passwordsMismatch}
+              helperText={passwordsMismatch ? t('signup.passwordMismatch') : ''}
               slotProps={{
                 input: {
                   startAdornment: <LockOpenIcon size={22} style={{ color: "#777", marginRight: "0.5rem", transform: "translateY(-2px)" }} />,
                   disableUnderline: true,
                   onKeyPress: handleKeyPress,
                   endAdornment: (
-                    <IconButton type="submit" disabled={isLoading}>
+                    <IconButton type="submit" disabled={isLoading || passwordsMismatch}>
                       <ArrowCircleRightIcon
                         size={22}
-                        style={{ color: "#888", cursor: "pointer", transform: "translateY(-2px)" }}
-                      />
+                        style={{ color: "#888", cursor: "pointer", transform: "translateY(-2px)" }} />
                     </IconButton>
                   ),
                 }

--- a/v2/src/components/Signup/style.scss
+++ b/v2/src/components/Signup/style.scss
@@ -1,0 +1,44 @@
+.loginWrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 32px 16px;
+  width: 100%;
+  min-height: calc(100dvh - 40px); // keep footer visible
+}
+
+.loginContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background-color: transparent;
+}
+
+.d-flex-center {
+  display: flex;
+  justify-content: center;
+}
+
+.logoImg {
+  width: 180px;
+  border-radius: 50%;
+}
+
+.text-field {
+  box-sizing: border-box;
+  padding: 0.3rem;
+  border: 1px solid #cecece;
+  border-radius: 0.45rem;
+  width: 350px;
+}
+
+.MuiInputBase-input {
+  font-size: 0.875rem;
+}
+
+@media (max-width: 768px) {
+  .titleTxt {
+    font-size: 1rem !important;
+  }
+}

--- a/v2/src/constants/routes.ts
+++ b/v2/src/constants/routes.ts
@@ -1,7 +1,7 @@
 export const publicRoutes = new Set([
   '/',
   '/login',
-  '/register',
+  '/signup',
   '/forgot-password',
   '/reset-password',
   '/data-source/read',

--- a/v2/src/custom-hooks/auth.ts
+++ b/v2/src/custom-hooks/auth.ts
@@ -66,14 +66,13 @@ export const useLogin = () => {
       }, 500);
     },
     onError: (error: unknown) => {
-      // Send a global error message so AppLayout can display it
       let errText = 'Login failed';
-      // Try to extract a server-provided message
       try {
         const anyErr = error as any;
         const data = anyErr?.response?.data;
         if (typeof data === 'string') errText = data;
         else if (data?.detail) errText = data.detail;
+        else if (data?.message) errText = data.message;
         else if (anyErr?.message) errText = anyErr.message;
       } catch {}
       dispatch(setSuccessMessage(''));
@@ -101,10 +100,9 @@ export const useSignup = () => {
       return apiService.signup(email, password, name);
     },
     onSuccess: () => {
-      // Clear any previous errors
+      // Clear any previous messages and suppress success toast
       dispatch(setMessage(''));
-      // Optionally set success (AppLayout suppresses success toasts)
-      dispatch(setSuccessMessage('Signup successful'));
+      dispatch(setSuccessMessage(''));
       // Navigate to login
       setTimeout(() => {
         router.push('/login');
@@ -117,6 +115,8 @@ export const useSignup = () => {
         const data = anyErr?.response?.data;
         if (typeof data === 'string') errText = data;
         else if (data?.detail) errText = data.detail;
+        else if (data?.message) errText = data.message;
+        else if (data?.email?.length) errText = data.email.join(", ");
         else if (anyErr?.message) errText = anyErr.message;
       } catch {}
       dispatch(setSuccessMessage(''));

--- a/v2/src/layouts/minimal/MinimalLayout.tsx
+++ b/v2/src/layouts/minimal/MinimalLayout.tsx
@@ -8,13 +8,13 @@ import Breadcrumb from '@/components/common/Breadcrumb';
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
   const pathname = usePathname();
-  const isLoginRoute = pathname.includes('/login');
+  const isAuthRoute = pathname.includes('/login') || pathname.includes('/signup');
   return (
     <>
-      {isLoginRoute ? null : <MinimalAppBar />}
+      {isAuthRoute ? null : <MinimalAppBar />}
       <Box className="leftNavigationContainer">
-        <Box component="main" sx={{ paddingTop: isLoginRoute ? 0 : '80px', flex: 1 }}>
-          {!isLoginRoute && (
+        <Box component="main" sx={{ paddingTop: isAuthRoute ? 0 : '80px', flex: 1 }}>
+          {!isAuthRoute && (
             <Suspense fallback={null}>
               <Breadcrumb />
             </Suspense>

--- a/v2/src/lib/apiService/apiEndpoints.ts
+++ b/v2/src/lib/apiService/apiEndpoints.ts
@@ -3,6 +3,9 @@ export const ENDPOINTS = {
     login: () => {
         return "/onboard/login/";
     },
+    signup: () => {
+        return "/onboard/register/";
+    },
     logout: () => { return "/onboard/logout" },
     refreshToken: () => {
         return "/onboard/token/refresh";

--- a/v2/src/lib/apiService/apiService.ts
+++ b/v2/src/lib/apiService/apiService.ts
@@ -18,6 +18,12 @@ export const apiService = {
       { email, password }
     ).then(res => res.data);
   },
+  signup: async (email: string, password: string, name?: string): Promise<{ id: string; email: string; name?: string }> => {
+    return api.post<{ id: string; email: string; name?: string }>(
+      ENDPOINTS.signup(),
+      { email, password, name }
+    ).then(res => res.data);
+  },
   dataSourceList: async (): Promise<DataSourceListResponse> => {
     return api.get<DataSourceListResponse>(ENDPOINTS.dataSourceList())
       .then(res => res.data);

--- a/v2/src/lib/apiService/axios.ts
+++ b/v2/src/lib/apiService/axios.ts
@@ -34,7 +34,15 @@ export const createAxiosInstance = (options: { isArrayBuffer?: boolean } = {}) =
   instance.interceptors.request.use((config) => {
     // Check if we're in a logged out state and this is an API request
     // Skip this check for login/authentication endpoints
-    const isAuthEndpoint = config.url?.includes('/auth/') || config.url?.includes('/login');
+    const isAuthEndpoint = (
+      config.url?.includes('/auth/') ||
+      config.url?.includes('/login') ||
+      // Frontend route alias
+      config.url?.includes('/signup') ||
+      // Backend signup endpoint
+      config.url?.includes('/onboard/register') ||
+      config.url?.includes('/token/refresh')
+    );
     
     if (!isAuthenticated && !isAuthEndpoint && config.url?.startsWith('/')) {
       // Cancel the request if we're not authenticated

--- a/v2/src/translations/en.json
+++ b/v2/src/translations/en.json
@@ -23,7 +23,9 @@
     "header": "CRANE dHDSI - Organisation dashboard - Signup",
     "name": "Name",
     "email": "Email",
+    "userId": "User ID",
     "confirmPassword": "Confirm Password",
+    "passwordMismatch": "Passwords do not match",
     "haveAccount": "Already have an account?",
     "login": "Log in",
     "title": "Signup"

--- a/v2/src/translations/en.json
+++ b/v2/src/translations/en.json
@@ -10,11 +10,23 @@
     "apiDoc": "/data-source/open-api"
   },
   "login": {
-    "header": "CRANE dHDSI - Organisation dashboard",
+    "header": "CRANE dHDSI - Organisation dashboard - Login",
     "userId": "User ID",
     "password": "Password",
     "rememberMe": "Remember Me",
-    "errorMessage": "Invalid login credentials. Please double-check your username and password and try again."
+    "errorMessage": "Invalid login credentials. Please double-check your username and password and try again.",
+    "title": "Login",
+    "noAccount": "Don't have an account?",
+    "signup": "Signup"
+  },
+  "signup": {
+    "header": "CRANE dHDSI - Organisation dashboard - Signup",
+    "name": "Name",
+    "email": "Email",
+    "confirmPassword": "Confirm Password",
+    "haveAccount": "Already have an account?",
+    "login": "Log in",
+    "title": "Signup"
   },
   "breadcrumbs": {
     "home": "Home",
@@ -96,6 +108,7 @@
     "industry": "Industry"
   },
   "common": {
+    "orgDashboardTitle": "CRANE dHDSI - Organisation dashboard",
     "trustedServiceProvider": "Trusted Service Provider",
     "untrustedServiceProvider": "Untrusted Service Provider",
     "continue": "Continue",

--- a/v2/src/translations/fi.json
+++ b/v2/src/translations/fi.json
@@ -10,11 +10,22 @@
     "apiDoc": "/data-source/open-api"
   },
   "login": {
-    "header": "CRANE dHDSI - Organisaation hallintapaneeli",
+    "header": "CRANE dHDSI - Organisaation hallintapaneeli - Kirjaudu",
     "userId": "Käyttäjätunnus",
     "password": "Salasana",
     "rememberMe": "Muista minut",
-    "errorMessage": "Virheelliset kirjautumistiedot. Tarkista käyttäjätunnus ja salasana ja yritä uudelleen."
+    "errorMessage": "Virheelliset kirjautumistiedot. Tarkista käyttäjätunnus ja salasana ja yritä uudelleen.",
+    "title": "Kirjaudu",
+    "noAccount": "Eikö sinulla ole tiliä?",
+    "signup": "Luo tili"
+  },
+  "signup": {
+    "header": "CRANE dHDSI - Organisaation hallintapaneeli - Luo tili",
+    "name": "Nimi",
+    "confirmPassword": "Vahvista salasana",
+    "haveAccount": "Onko sinulla jo tili?",
+    "login": "Kirjaudu sisään",
+    "title": "Luo tili"
   },
   "breadcrumbs" : {
     "home": "Koti",
@@ -123,6 +134,7 @@
     "industry": "Toimiala"
   },
   "common": {
+    "orgDashboardTitle": "CRANE dHDSI - Organisaation hallintapaneeli",
     "trustedServiceProvider": "Luotettu palveluntarjoaja",
     "untrustedServiceProvider": "Luottamaton palveluntarjoaja",
     "continue": "Jatka",

--- a/v2/src/translations/fi.json
+++ b/v2/src/translations/fi.json
@@ -23,6 +23,8 @@
     "header": "CRANE dHDSI - Organisaation hallintapaneeli - Luo tili",
     "name": "Nimi",
     "confirmPassword": "Vahvista salasana",
+    "userId": "Käyttäjätunnus",
+    "passwordMismatch": "Salasanat eivät täsmää",
     "haveAccount": "Onko sinulla jo tili?",
     "login": "Kirjaudu sisään",
     "title": "Luo tili"

--- a/v2/src/translations/sv.json
+++ b/v2/src/translations/sv.json
@@ -10,11 +10,22 @@
     "apiDoc": "/data-source/open-api"
   },
   "login": {
-    "header": "CRANE dHDSI - Organisationspanel",
+    "header": "CRANE dHDSI - Organisationspanel - Logga in",
     "userId": "Användar-ID",
     "password": "Lösenord",
     "rememberMe": "Kom ihåg mig",
-    "errorMessage": "Ogiltiga inloggningsuppgifter. Dubbelkolla ditt användarnamn och lösenord och försök igen."
+    "errorMessage": "Ogiltiga inloggningsuppgifter. Dubbelkolla ditt användarnamn och lösenord och försök igen.",
+    "title": "Logga in",
+    "noAccount": "Har du inget konto?",
+    "signup": "Skapa konto"
+  },
+  "signup": {
+    "header": "CRANE dHDSI - Organisationspanel - Skapa konto",
+    "name": "Namn",
+    "confirmPassword": "Bekräfta lösenord",
+    "haveAccount": "Har du redan ett konto?",
+    "login": "Logga in",
+    "title": "Skapa konto"
   },
   "breadcrumbs": {
     "home": "Hem",
@@ -123,6 +134,7 @@
     }
   },
   "common": {
+    "orgDashboardTitle": "CRANE dHDSI - Organisationspanel",
     "trustedServiceProvider": "Pålitlig tjänsteleverantör",
     "untrustedServiceProvider": "Opålitlig tjänsteleverantör",
     "continue": "Fortsätt",

--- a/v2/src/translations/sv.json
+++ b/v2/src/translations/sv.json
@@ -23,6 +23,8 @@
     "header": "CRANE dHDSI - Organisationspanel - Skapa konto",
     "name": "Namn",
     "confirmPassword": "Bekräfta lösenord",
+    "passwordMismatch": "Lösenorden matchar inte",
+    "userId": "Användar-ID",
     "haveAccount": "Har du redan ett konto?",
     "login": "Logga in",
     "title": "Skapa konto"


### PR DESCRIPTION
Changes: 
- Signup page added
- api calls point to `/onboard/register`
- Added links below login form to switch to signup page from login page
- Toast error notifications fixed for login page also
- Above login form, there is a login heading now

Signup page:
<img width="1726" height="970" alt="image" src="https://github.com/user-attachments/assets/a33ba46a-bc4e-4aae-9907-40bd4837b8a8" />

Login page: 
<img width="1726" height="970" alt="image" src="https://github.com/user-attachments/assets/4832d61f-8bbe-4075-b4e1-a5103758c0c4" />

