### PR TITLE
Fix #386: set Secure attribute on auth cookies

### DIFF
--- a/src/utils/browserStorage.ts
+++ b/src/utils/browserStorage.ts
@@ -25,13 +25,14 @@ export const clearAllBrowserStorage = async () => {
     // Clear all cookies accessible to JS (HttpOnly cookies cannot be cleared from JS)
     try {
       const cookies = document.cookie.split(';');
+      const secureFlag = window.location.protocol === 'https:' ? ';Secure' : '';
       for (const cookie of cookies) {
         const eqPos = cookie.indexOf('=');
         const name = eqPos > -1 ? cookie.substr(0, eqPos) : cookie;
         // Remove cookie for root path
-        document.cookie = `${name.trim()}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/`;
+        document.cookie = `${name.trim()}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/${secureFlag}`;
         // Attempt removal without path (fallback)
-        document.cookie = `${name.trim()}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;`;
+        document.cookie = `${name.trim()}=;expires=Thu, 01 Jan 1970 00:00:00 GMT${secureFlag}`;
       }
     } catch (e) {
       // ignore

--- a/src/utils/cookieService.ts
+++ b/src/utils/cookieService.ts
@@ -5,6 +5,7 @@ import { AccessToken, User } from '@/types/auth';
 
 // Cookie expiration in days
 const TOKEN_EXPIRATION = 7;
+const isSecure = process.env.NODE_ENV === 'production';
 
 export const CookieService = {
   // Set token in both cookie and localStorage for compatibility
@@ -13,28 +14,32 @@ export const CookieService = {
     Cookies.set('access_token', token.access_token, { 
       expires: TOKEN_EXPIRATION,
       path: '/',
-      sameSite: 'lax'
+      sameSite: 'lax',
+      secure: isSecure
     });
     
     // Store refresh token as a string
     Cookies.set('refresh_token', token.refresh_token, { 
       expires: TOKEN_EXPIRATION,
       path: '/',
-      sameSite: 'lax'
+      sameSite: 'lax',
+      secure: isSecure
     });
     
     // Store token expiration info
     Cookies.set('token_expires_in', String(token.expires_in), { 
       expires: TOKEN_EXPIRATION,
       path: '/',
-      sameSite: 'lax'
+      sameSite: 'lax',
+      secure: isSecure
     });
     
     // Also set a lightweight client auth flag used by middleware routing
     Cookies.set('client_auth', '1', {
       expires: TOKEN_EXPIRATION,
       path: '/',
-      sameSite: 'lax'
+      sameSite: 'lax',
+      secure: isSecure
     });
     
     // Also store in localStorage for client-side access (keeping for compatibility)


### PR DESCRIPTION
Sensitive cookies (access_token, refresh_token, etc.) were being set without the Secure attribute, allowing transmission over unencrypted HTTP connections.

Changes:
- cookieService.ts: Add secure: true in production for all auth cookies
- browserStorage.ts: Add Secure flag to cookie deletion in HTTPS contexts

This protects cookies from man-in-the-middle attacks when the app is served over HTTPS.