### PR TITLE
Reduce data source card height for two-row visibility

### DIFF
--- a/src/components/Home/DataSource.tsx
+++ b/src/components/Home/DataSource.tsx
@@ -94,7 +94,7 @@ const DataSourceCard = ({ dataSource, dataDisclosureAgreements, overviewLabel, s
                     className='card-header'
                     image={dataSource?.coverImageUrl}
                     sx={{
-                        height: '100px',
+                        height: '65px',
                         position: 'relative',
                         backgroundSize: 'cover',
                         backgroundPosition: 'center'
@@ -105,20 +105,20 @@ const DataSourceCard = ({ dataSource, dataDisclosureAgreements, overviewLabel, s
                         alt={dataSource?.name || 'Data Source'}
                         sx={{
                             position: 'absolute',
-                            top: '50px',
-                            left: '16px',
-                            width: '80px',
-                            height: '80px',
+                            top: '36px',
+                            left: '12px',
+                            width: '56px',
+                            height: '56px',
                             backgroundColor: 'white',
                             boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
-                            border: '4px solid white',
+                            border: '3px solid white',
                             zIndex: 1,
                         }}
                         imgProps={{ style: { objectFit: 'cover', width: '100%', height: '100%', display: 'block' } }}
                     />
                 </CardMedia>
-                <CardContent sx={{ padding: "20px" }}>
-                    <Typography variant="h6" fontWeight="bold" className="org-name" sx={{ mb: 1, display: 'flex', alignItems: 'center', gap: 1 }}>
+                <CardContent sx={{ padding: "14px 16px 16px" }}>
+                    <Typography variant="subtitle1" fontWeight="bold" className="org-name" sx={{ mb: 0.5, display: 'flex', alignItems: 'center', gap: 0.5, fontSize: '0.95rem', color: '#1d1d1f' }}>
                         {dataSource?.name}
                         {/* Public page shield: show credential if verified, otherwise not-allowed and no click */}
                         <ViewCredentialsController
@@ -141,20 +141,15 @@ const DataSourceCard = ({ dataSource, dataDisclosureAgreements, overviewLabel, s
                     </Typography>
                     {/* Access Point Endpoint removed from below avatar section */}
                     {dataSource?.location && (
-                        <Typography variant="body2" className="datasource-location" sx={{ mb: 1 }}>
+                        <Typography variant="body2" className="datasource-location" sx={{ mb: 0.5 }}>
                             {dataSource.location}
                         </Typography>
                     )}
-                    <Typography variant="subtitle1" className='datasource-overview-label'>
+                    <Typography variant="subtitle2" className='datasource-overview-label'>
                         {overviewLabel}
                     </Typography>
-                    <Typography gutterBottom component="div" className="card-body datasource-overview" sx={{ fontSize: "14px" }}>
-                        {dataSource?.description.slice(0, 275)}
-                        {dataSource?.description?.length > 275 &&
-                            <Typography className="readmore" component="span" sx={{ fontSize: "14px" }}>
-                                {/* <Box onClick={() => readMore(moreOrLessTxt)}>({moreOrLessTxt})</Box> */}
-                            </Typography>
-                        }
+                    <Typography gutterBottom component="div" className="card-body datasource-overview" sx={{ fontSize: "13px" }}>
+                        {dataSource?.description}
                     </Typography>
 
                     <Box className="actionBtn">

--- a/src/components/Home/style.scss
+++ b/src/components/Home/style.scss
@@ -29,50 +29,55 @@
 
     .cardContainer {
         background-color: white;
-        border: 1px solid rgba(0, 0, 0, 0.06);
-        border-radius: 20px;
+        border: 1px solid rgba(0, 0, 0, 0.08);
+        border-radius: 16px;
         padding: 0;
-        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+        box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06), 0 2px 12px rgba(0, 0, 0, 0.04);
         transition: box-shadow 0.3s ease, transform 0.3s ease;
         overflow: visible;
+        display: flex;
+        flex-direction: column;
 
         &:hover {
-            box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+            box-shadow: 0 8px 24px rgba(0, 0, 0, 0.10);
             transform: translateY(-2px);
         }
 
         .logo {
-            width: 80px;
-            height: 80px;
+            width: 56px;
+            height: 56px;
             border-radius: 50%;
             position: absolute;
-            top: 50px;
-            left: 16px;
-            border: 4px solid white;
+            top: 36px;
+            left: 14px;
+            border: 3px solid white;
             background-color: white;
             object-fit: cover;
-            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
             z-index: 1;
         }
 
         .card-header {
             display: flex;
             justify-content: flex-start;
-            height: 100px;
+            height: 65px;
             position: relative;
-            border-radius: 20px 20px 0 0;
+            border-radius: 16px 16px 0 0;
             overflow: visible;
         }
 
         .card-header + .MuiCardContent-root {
-            margin-top: 12px;
+            margin-top: 8px;
         }
 
         .MuiCardContent-root {
-            padding: 20px !important;
+            padding: 14px 16px 16px !important;
+            flex: 1;
+            display: flex;
+            flex-direction: column;
 
             .MuiTypography-root {
-                padding: 28px 0 0 0;
+                padding: 16px 0 0 0;
 
                 .readmore {
                     color: #86868b;
@@ -81,46 +86,54 @@
 
             .card-body {
                 overflow: hidden;
-                padding: 12px 0 0 0;
+                padding: 4px 0 0 0;
             }
 
             .datasource-location {
                 padding-top: 0;
-                color: #86868b;
+                color: #6e6e73;
                 font-size: 13px;
+                letter-spacing: 0.01em;
             }
 
             .datasource-overview-label {
-                padding-top: 8px;
+                padding-top: 6px;
                 font-weight: 600;
-                font-size: 14px;
+                font-size: 13px;
                 color: #1d1d1f;
             }
 
             .datasource-overview {
-                padding-top: 6px;
-                color: #424245;
+                padding-top: 3px;
+                color: #48484a;
                 font-size: 13px;
-                line-height: 1.6;
+                line-height: 1.5;
+                display: -webkit-box;
+                -webkit-line-clamp: 2;
+                -webkit-box-orient: vertical;
+                overflow: hidden;
+                text-overflow: ellipsis;
             }
         }
 
         .actionBtn {
+            margin-top: auto;
+
             .MuiButtonBase-root,
             a,
             span {
                 width: 100%;
                 display: block;
                 text-align: center;
-                padding: 10px 16px;
-                font-size: 14px;
+                padding: 8px 12px;
+                font-size: 13px;
                 font-weight: 500;
                 text-transform: none;
-                border: 1px solid rgba(0, 0, 0, 0.08);
+                border: 1px solid rgba(0, 0, 0, 0.10);
                 background: #f5f5f7;
                 border-radius: 980px;
                 color: #1d1d1f;
-                margin-top: 12px;
+                margin-top: 10px;
                 transition: all 0.2s ease;
                 letter-spacing: -0.01em;
                 text-decoration: none;


### PR DESCRIPTION
## Summary
- Reduced cover image height (100px → 65px) and avatar size (80px → 56px) so two full rows of data source cards are visible without scrolling
- Replaced character-based description truncation (275 chars) with CSS `-webkit-line-clamp: 2` for consistent text overflow
- Cards now use flexbox column layout so the action button stays anchored at the bottom regardless of content length
- Slightly improved text contrast and spacing for better readability

## Test plan
- [x] Verify two rows of cards are fully visible on the landing page without scrolling
- [x] Check card layout at different breakpoints (mobile, tablet, desktop)
- [x] Confirm description text truncates with ellipsis after 2 lines
- [x] Verify "View Data Disclosure Agreements" button stays at card bottom
- [x] Check hover effects still work correctly